### PR TITLE
Fix CI (enable GitHub actions, update QUnit/PHPUnit)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,45 @@
+name: Test
+
+on:
+  - push
+  - pull_request
+
+jobs:
+
+  php:
+    name: PHPUnit
+
+    strategy:
+      fail-fast: false
+
+    # Includes PHP 8.1
+    # https://github.com/actions/runner-images/blob/ubuntu22/20240714.1/images/ubuntu/Ubuntu2204-Readme.md
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress --no-suggest
+
+    - name: Test
+      run: composer test
+
+  js:
+    name: QUnit
+
+    strategy:
+      fail-fast: false
+
+    # Includes Node.js 18
+    # https://github.com/actions/runner-images/blob/ubuntu22/20240714.1/images/ubuntu/Ubuntu2204-Readme.md
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - run: npm install
+
+    - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,13 @@
 ## Directory-based project format:
 .idea/
 
-# Dependency directory
-# https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
-node_modules
+### npm test
+### https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
+/node_modules
+/package-lock.json
 
-### Composer template
-composer.phar
+### composer test
+/composer.phar
 /vendor/
+/composer.lock
+/.phpunit.result.cache

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
             }
         },
         eslint: {
-            target: "js/babel/app.js",
+            target: "js/src/babel/app.js",
             options: {
                 configFile: 'conf/eslint.json'
             }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,8 @@
 {
   "require-dev": {
-    "phpunit/phpunit": "^4.8"
+    "phpunit/phpunit": "^8.0"
+  },
+  "scripts": {
+    "test": "phpunit"
   }
 }

--- a/js/src/babel/app.js
+++ b/js/src/babel/app.js
@@ -24,5 +24,5 @@ let stopSpamming = (function (config) {
     // Call init
     init();
 
-    return {/* silence is gold */}
+    return {/* silence is gold */};
 })({emailSelector: '.profile-contact span', domain: 'nationalarchives.gov.uk'});

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "tna-profile-page",
   "version": "0.1.0",
+  "scripts": {
+    "test": "grunt eslint qunit"
+  },
   "devDependencies": {
     "babel-preset-env": "^1.1.11",
     "grunt": "^1.0.1",
     "grunt-babel": "^6.0.0",
     "grunt-contrib-concat": "^1.0.1",
-    "grunt-contrib-qunit": "^1.2.0",
+    "grunt-contrib-qunit": "^10.0.0",
     "grunt-contrib-sass": "^1.0.0",
     "grunt-contrib-uglify": "^2.0.0",
     "grunt-contrib-watch": "^1.0.0",


### PR DESCRIPTION
grunt-contrib-qunit v1 used PhantomJS which no longer works on
current OS versions. The latest uses Headless Chrome instead.

https://github.com/gruntjs/grunt-contrib-qunit

PHPUnit 4 encounters deprecation warnings or errors in PHP 7 and 8,
update to PHPUnit 8, which supports PHP 7.2+.

https://phpunit.de/supported-versions.html

The ESLint step was broken because "js/babel/app.js" does not exist.
I assume this is meant to be "js/src/babel/app.js" as other steps
refer to. One lint issue snuck in since that broke, which I fixed.